### PR TITLE
BUGFIX: Prevent `docker tag` from using the wrong image (of a higher Node version)

### DIFF
--- a/script/push_dockers.sh
+++ b/script/push_dockers.sh
@@ -8,7 +8,7 @@ do
   CHROMIUM_VERSION=`docker run alpine/semver semver -c $(docker-compose run node_$version chromium-browser --version)`
 
   # Make tags
-  tags="$tags $NODE_VERSION-chromium_$CHROMIUM_VERSION-${CIRCLE_BRANCH//\//_}"
+  tags="$NODE_VERSION-chromium_$CHROMIUM_VERSION-${CIRCLE_BRANCH//\//_}"
   tags="$tags $NODE_VERSION-chromium_$CHROMIUM_VERSION-${CIRCLE_BRANCH//\//_}-$CIRCLE_SHA1"
 
   for tag in $tags


### PR DESCRIPTION
script/push_dockers.sh bugfix: initialize `tags` var in outer `version` loop to prevent tags sometimes being changed to reference the `BASE_IMAGE` for one even-numbered Node version higher

Example: copied and pasted from current first page of https://quay.io/repository/nyulibraries/chromium_headless_node?tab=tags:

> 12-chromium_latest | 14 hours ago | Passed | 177.0 MB | Never | SHA256 af591c254b11 |  
-- | -- | -- | -- | -- | -- | --

Here's the manifest -- [ af591c254b11](https://quay.io/repository/nyulibraries/chromium_headless_node/manifest/sha256:af591c254b11e769443cdabb5454bc7fe3f1b45f680dc564a026166afb0eaa48), which show that Node 14 and not 12 is being used:

```
NODE_VERSION=14.20.1
```

...which was the result of a CircleCI job like [this one](https://app.circleci.com/pipelines/github/NYULibraries/chromium_headless_node/975/workflows/7d3e1a76-fb70-4166-b469-bdc521eb21b7/jobs/1227/parallel-runs/0/steps/0-105) -- which has this incorrect `docker tag` command:

```
+ docker tag chromium_headless_node:14 quay.io/nyulibraries/chromium_headless_node:12-chromium_latest
```
 