### PR TITLE
Add node versions up to 20 and remove versions 12 and 14

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-for i in 12 14
+for i in 12 14 16 18 20
 do
   SERVICE=alpine_node_${i}
   docker-compose build ${SERVICE}

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-for i in 12 14 16 18 20
+for i in 16 18 20
 do
   SERVICE=alpine_node_${i}
   docker-compose build ${SERVICE}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,20 +1,6 @@
 version: '3.7'
 
 services:
-  node_12:
-    build:
-      context: .
-      args:
-        NODE_VERSION: ${NODE_VERSION:-12}
-    image: chromium_headless_node:12
-
-  node_14:
-    build:
-      context: .
-      args:
-        NODE_VERSION: ${NODE_VERSION:-14}
-    image: chromium_headless_node:14
-
   node_16:
     build:
       context: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,3 +14,24 @@ services:
       args:
         NODE_VERSION: ${NODE_VERSION:-14}
     image: chromium_headless_node:14
+
+  node_16:
+    build:
+      context: .
+      args:
+        NODE_VERSION: ${NODE_VERSION:-16}
+    image: chromium_headless_node:16
+
+  node_18:
+    build:
+      context: .
+      args:
+        NODE_VERSION: ${NODE_VERSION:-18}
+    image: chromium_headless_node:18
+
+  node_20:
+    build:
+      context: .
+      args:
+        NODE_VERSION: ${NODE_VERSION:-20}
+    image: chromium_headless_node:20

--- a/script/push_dockers.sh
+++ b/script/push_dockers.sh
@@ -1,6 +1,6 @@
 #!/bin/sh -ex
 
-for version in 12 14
+for version in 12 14 16 18 20
 do
   BASE_IMAGE=chromium_headless_node:$version
   # grabs version number from Node & Chromium installations, stripping extraneous text

--- a/script/push_dockers.sh
+++ b/script/push_dockers.sh
@@ -1,6 +1,6 @@
 #!/bin/sh -ex
 
-for version in 12 14 16 18 20
+for version in 16 18 20
 do
   BASE_IMAGE=chromium_headless_node:$version
   # grabs version number from Node & Chromium installations, stripping extraneous text


### PR DESCRIPTION
* Version 20 is required for bess-vue.
* Removed versions 12 and 14.  Version 12 build is broken: https://app.circleci.com/pipelines/github/NYULibraries/chromium_headless_node/1511/workflows/172bb571-8542-440e-a9ff-ae02ac271734/jobs/1763/parallel-runs/0/steps/0-104
  * Did a search to see if 12 or earlier is needed: https://github.com/search?q=org%3ANYULibraries%20chromium_headless_node&type=code
  * Only versions 10, 12, and 14 are being used.  10 and 12 are being used by retired projects, and 14 is used by bess-vue, for which we are adding version 20 so we can upgrade it after node-sass is removed.
